### PR TITLE
Use project layout at the generate task configuration

### DIFF
--- a/src/main/kotlin/net/pwall/json/kotlin/codegen/gradle/JSONSchemaCodegenPlugin.kt
+++ b/src/main/kotlin/net/pwall/json/kotlin/codegen/gradle/JSONSchemaCodegenPlugin.kt
@@ -27,12 +27,11 @@ package net.pwall.json.kotlin.codegen.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 @Suppress("unused")
 class JSONSchemaCodegenPlugin : Plugin<Project> {
@@ -44,7 +43,7 @@ class JSONSchemaCodegenPlugin : Plugin<Project> {
             description = "Generates code for specified schemata"
             group = "build"
         }
-        project.tasks.withType<KotlinCompilationTask<KotlinCommonCompilerOptions>>().configureEach {
+        project.tasks.withType<JavaCompile>().configureEach {
             dependsOn(generateTask)
         }
     }

--- a/src/main/kotlin/net/pwall/json/kotlin/codegen/gradle/JSONSchemaCodegenTask.kt
+++ b/src/main/kotlin/net/pwall/json/kotlin/codegen/gradle/JSONSchemaCodegenTask.kt
@@ -43,8 +43,7 @@ open class JSONSchemaCodegenTask : DefaultTask() {
         val ext: JSONSchemaCodegen = project.the()
         CodeGenerator().apply {
             nestedClassNameOption = CodeGenerator.NestedClassNameOption.USE_NAME_FROM_PROPERTY
-            val configFile = ext.configFile.orNull ?:
-                    File("src/main/resources/codegen-config.json").takeIf { it.exists() }
+            val configFile = ext.configFile.orNull ?: project.file(DEFAULT_CONFIGURATION).takeIf { it.exists() }
             configFile?.let { configure(it, it.toURI()) }
             val parser = schemaParser
             if (ext.schemaExtensions.isNotEmpty()) {
@@ -64,7 +63,8 @@ open class JSONSchemaCodegenTask : DefaultTask() {
                     else -> throw IllegalArgumentException("Unrecognised language - $it")
                 }
             }
-            val outputDir = ext.outputDir.orNull ?: File("build/generated-sources/${targetLanguage.directory()}")
+            val outputDir = ext.outputDir.orNull ?:
+                project.buildDir.resolve("generated-sources/${targetLanguage.directory()}")
             baseDirectoryName = outputDir.path
             ext.classMappings.forEach {
                 it.applyTo(this)
@@ -88,7 +88,7 @@ open class JSONSchemaCodegenTask : DefaultTask() {
                         addTargets(listOf(inputFile))
                 }
                 pointer != null -> throw IllegalArgumentException("Pointer with no composite input file")
-                numTargets == 0 -> addTargets(listOf(defaultInputLocation))
+                numTargets == 0 -> addTargets(listOf(project.file(DEFAULT_INPUT_LOCATION)))
             }
             ext.indexFileName.orNull?.let {
                 indexFileName = if (it.contains('.'))
@@ -103,7 +103,8 @@ open class JSONSchemaCodegenTask : DefaultTask() {
 
     companion object {
 
-        private val defaultInputLocation = File("src/main/resources/schema")
+        private const val DEFAULT_INPUT_LOCATION = "src/main/resources/schema"
+        private const val DEFAULT_CONFIGURATION = "src/main/resources/codegen-config.json"
 
         private fun TargetLanguage.directory() = when (this) {
             TargetLanguage.KOTLIN -> "kotlin"


### PR DESCRIPTION
This pull-request fixes part of the issue #14 , making the `generate` task configuration scoped to the current submodule. This is done by using the project's layout, instead of creating File objects in the codegen task.

In addition, makes the task depend on `JavaCompile`, instead of `KotlinCompilationTask`. This makes the Java generation behavior be consistent with the Kotlin one, as the `generate` task gets invoked before Java compilation time.